### PR TITLE
add optional callback method to notify evictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ operations are shown below:
 **Creation**
 
 ```julia
-lru = LRU{K, V}([, maxsize=100])
+lru = LRU{K, V}([, maxsize=100]; callback=cb)
 ```
 
 Create an LRU Cache with maximum size `maxsize`. If `maxsize` is not provided,
 a default of `100` is used.
+
+When an item is being evicted from the cache, the callback function `cb` will be called with its key and value.
 
 **Add an item to the cache**
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -86,10 +86,35 @@ end
 # Test Abstract typed cache. All we're checking for here is that the container
 # is able to hold abstract types without issue. Insertion order is already
 # tested above.
-const CACHE2 = LRU{String, Integer}(5)
+const CACHE2 = LRU{AbstractString, Integer}(5)
 CACHE2["test"] = 4
 CACHE2[utf8("test2")] = BigInt(5)
 @test CACHE2["test"] == 4
 @test CACHE2["test2"] == 5
+
+# Test callbacks
+function test_cb()
+    removed = Tuple[]
+    CACHE3 = LRU{Int, Int}(3; callback=(x,y)->push!(removed, (x,y)))
+    for i in 1:5
+        CACHE3[i] = i*10
+    end
+
+    @test length(removed) == 2
+    for i in 1:2
+        x,y = shift!(removed)
+        @test x == i
+        @test y == x * 10
+    end
+
+    empty!(CACHE3)
+    @test length(removed) == 3
+    for i in 3:5
+        x,y = shift!(removed)
+        @test 2 < x < 6
+        @test y == x * 10
+    end
+end
+test_cb()
 
 end


### PR DESCRIPTION
It is often useful to have notifications when an item is being evicted from the cache to cleanup some state or release resources.

With this PR, LRU cache can be created with an optional callback function which will be called when an item is being evicted from the cache.

Example:

```
julia> using LRUCache

julia> CACHE = LRU{Int, Int}(3; callback=(x,y)->println("removed $x=>$y"))
       for i in 1:4
           CACHE[i] = i*10
       end
removed 1=>10
```
