### PR TITLE
Remove `is` as it's Julia v0.6 deprecated

### DIFF
--- a/src/list.jl
+++ b/src/list.jl
@@ -100,7 +100,7 @@ end
 
 # Move the node n to the front of the list
 function move_to_front!{T}(l::LRUList{T}, n::LRUNode{T})
-    if !is(first(l), n)
+    if !(first(l) === n)
         pop!(l, n)
         unshift!(l, n)
     end


### PR DESCRIPTION
Change comparator `is` to !=== since from Julia v0.6 it's deprecated.