### PR TITLE
updates for julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  #- release
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4-
+julia 0.7-alpha

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -7,16 +7,16 @@ include("list.jl")
 # Default cache size
 const __MAXCACHE__ = 100
 
-type LRU{K,V} <: Associative{K,V}
+mutable struct LRU{K,V} <: AbstractDict{K,V}
     ht::Dict{K, LRUNode{K, V}}
     q::LRUList{K, V}
     maxsize::Int
 
-    LRU(m::Int=__MAXCACHE__) = new(Dict{K, V}(), LRUList{K, V}(), m)
+    LRU{K, V}(m::Int=__MAXCACHE__) where {K, V} = new{K, V}(Dict{K, V}(), LRUList{K, V}(), m)
 end
 LRU(m::Int=__MAXCACHE__) = LRU{Any, Any}(m)
 
-Base.show{K, V}(io::IO, lru::LRU{K, V}) = print(io,"LRU{$K, $V}($(lru.maxsize))")
+Base.show(io::IO, lru::LRU{K, V}) where {K, V} = print(io,"LRU{$K, $V}($(lru.maxsize))")
 
 Base.start(lru::LRU) = start(lru.ht)
 Base.next(lru::LRU, state) = next(lru.ht, state)
@@ -41,7 +41,7 @@ macro get!(lru, key, default)
     end
 end
 
-function Base.get!{K,V}(default::Base.Callable, lru::LRU{K, V}, key::K)
+function Base.get!(default::Base.Callable, lru::LRU{K, V}, key::K) where {K,V}
     if haskey(lru, key)
         return lru[key]
     else
@@ -51,7 +51,7 @@ function Base.get!{K,V}(default::Base.Callable, lru::LRU{K, V}, key::K)
     end
 end
 
-function Base.get!{K,V}(lru::LRU{K,V}, key::K, default::V)
+function Base.get!(lru::LRU{K,V}, key::K, default::V) where {K,V}
     if haskey(lru, key)
         return lru[key]
     else
@@ -66,7 +66,7 @@ function Base.getindex(lru::LRU, key)
     return node.v
 end
 
-function Base.setindex!{K, V}(lru::LRU{K, V}, v, key)
+function Base.setindex!(lru::LRU{K, V}, v, key) where {K, V}
     if haskey(lru, key)
         item = lru.ht[key]
         item.v = v

--- a/src/list.jl
+++ b/src/list.jl
@@ -1,32 +1,32 @@
-type LRUNode{K, V}
+mutable struct LRUNode{K, V}
     k::K
     v::V
     next::LRUNode{K, V}
     prev::LRUNode{K, V}
 
     # All new created nodes are self referential only
-    function LRUNode{K, V}(k::K, v::V)
-        x = new(k, v)
+    function LRUNode{K, V}(k::K, v::V) where {K, V}
+        x = new{K, V}(k, v)
         x.next = x
         x.prev = x
         return x
     end
 end
 
-type LRUList{K, V}
-    first::Nullable{LRUNode{K, V}}
+mutable struct LRUList{K, V}
+    first::Union{LRUNode{K, V}, Nothing}
     size::Int
 
-    LRUList() = new(Nullable{LRUNode{K, V}}(), 0)
+    LRUList{K, V}() where {K, V} = new{K, V}(nothing, 0)
 end
 
-Base.first(l::LRUList) = !isempty(l) ? get(l.first) : error("LRUList is empty")
-Base.last(l::LRUList) = !isempty(l) ? get(l.first).prev : error("LRUList is empty")
+Base.first(l::LRUList) = !isempty(l) ? l.first : error("LRUList is empty")
+Base.last(l::LRUList) = !isempty(l) ? l.first.prev : error("LRUList is empty")
 
 Base.length(l::LRUList) = l.size
 Base.isempty(l::LRUList) = length(l) == 0
 
-function Base.show{K, V}(io::IO, l::LRUNode{K, V})
+function Base.show(io::IO, l::LRUNode{K, V}) where {K, V}
     print(io, "LRUNode{", K, ", ", V, "}(")
     show(io, l.k)
     print(io, ", ")
@@ -34,7 +34,7 @@ function Base.show{K, V}(io::IO, l::LRUNode{K, V})
     print(io, ")")
 end
 
-function Base.show{K, V}(io::IO, l::LRUList{K, V})
+function Base.show(io::IO, l::LRUList{K, V}) where {K, V}
     print(io, "LRUList{", K, ", ", V, "}(")
     if length(l) != 0
         f = first(l)
@@ -42,7 +42,7 @@ function Base.show{K, V}(io::IO, l::LRUList{K, V})
         print(io, "=>")
         show(io, f.v)
         n = f.next
-        while !is(n, f)
+        while n !== f
             print(io, ", ")
             show(io, n.k)
             print(io, "=>")
@@ -53,7 +53,7 @@ function Base.show{K, V}(io::IO, l::LRUList{K, V})
     print(io, ")")
 end
 
-function Base.push!{K, V}(list::LRUNode{K, V}, new::LRUNode{K, V})
+function Base.push!(list::LRUNode{K, V}, new::LRUNode{K, V}) where {K, V}
     new.next = list
     new.prev = list.prev
     list.prev.next = new
@@ -61,9 +61,9 @@ function Base.push!{K, V}(list::LRUNode{K, V}, new::LRUNode{K, V})
     return list
 end
 
-function Base.push!{K, V}(l::LRUList{K, V}, el::LRUNode{K, V})
+function Base.push!(l::LRUList{K, V}, el::LRUNode{K, V}) where {K, V}
     if isempty(l)
-        l.first = Nullable(el)
+        l.first = el
     else
         push!(first(l), el)
     end
@@ -71,12 +71,12 @@ function Base.push!{K, V}(l::LRUList{K, V}, el::LRUNode{K, V})
     return l
 end
 
-function Base.pop!{K, V}(l::LRUList{K, V}, n::LRUNode{K, V}=last(l))
-    if is(n.next, n)
-        l.first = Nullable{LRUNode{K, V}}()
+function Base.pop!(l::LRUList{K, V}, n::LRUNode{K, V}=last(l)) where {K, V}
+    if n.next === n
+        l.first = nothing
     else
-        if is(n, first(l))
-            l.first = Nullable(n.next)
+        if n === first(l)
+            l.first = n.next
         end
         n.next.prev = n.prev
         n.prev.next = n.next
@@ -85,7 +85,7 @@ function Base.pop!{K, V}(l::LRUList{K, V}, n::LRUNode{K, V}=last(l))
     return n
 end
 
-function Base.unshift!{K, V}(l::LRUList{K, V}, el::LRUNode{K, V})
+function Base.unshift!(l::LRUList{K, V}, el::LRUNode{K, V}) where {K, V}
     push!(l, el)
     rotate!(l)
 end
@@ -93,27 +93,27 @@ end
 # Rotate one step forward, so last element is now first
 function rotate!(l::LRUList)
     if length(l) > 1
-        l.first = Nullable(first(l).prev)
+        l.first = first(l).prev
     end
     return l
 end
 
 # Move the node n to the front of the list
-function move_to_front!{T}(l::LRUList{T}, n::LRUNode{T})
-    if !is(first(l), n)
+function move_to_front!(l::LRUList{T}, n::LRUNode{T}) where {T}
+    if first(l) !== n
         pop!(l, n)
         unshift!(l, n)
     end
     return l
 end
 
-function Base.delete!{K, V}(l::LRUList{K, V}, n::LRUNode{K, V})
+function Base.delete!(l::LRUList{K, V}, n::LRUNode{K, V}) where {K, V}
     pop!(l, n)
     return l
 end
 
-function Base.empty!{K, V}(l::LRUList{K, V})
-    l.first = Nullable{LRUNode{K, V}}()
+function Base.empty!(l::LRUList{K, V}) where {K, V}
+    l.first = nothing
     l.size = 0
     return l
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,7 +1,7 @@
 module Tests
 
 using LRUCache
-using Base.Test
+using Test
 
 function test_order(lru, keys, vals)
     if length(lru) != 0
@@ -10,7 +10,7 @@ function test_order(lru, keys, vals)
         @test f.v == vals[1]
         n = f.next
         i = 2
-        while !is(n, f)
+        while n !== f
             @test n.k == keys[i]
             @test n.v == vals[i]
             i += 1


### PR DESCRIPTION
Happy [Upgradathon Friday](https://discourse.julialang.org/t/ann-introducing-upgradathon-fridays/12047)! 

This PR fixes all the test errors and deprecation warnings on Julia v0.7. It also raises the minimum Julia version to v0.7-alpha. 

The only substantial change is the switch from `Nullable{LRUNode}` to `Union{LRUNode, Nothing}`. 