### PR TITLE
Add default (non-parameterized) constructor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.1
-  - julia_version: 1.2
-  - julia_version: 1.3
+  - julia_version: 1.4
   - julia_version: nightly
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
+  - 1.4
   - nightly
 env:
   - JULIA_NUM_THREADS=1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LRUCache"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
-version = "1.0.3"
+version = "1.1.0"
 
 [compat]
 julia = "1"

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -21,6 +21,8 @@ mutable struct LRU{K,V} <: AbstractDict{K,V}
         new{K, V}(Dict{K, V}(), CyclicOrderedSet{K}(), 0, maxsize, SpinLock(), by)
 end
 
+LRU(; maxsize::Int, by::Callable = _constone) = LRU{Any,Any}(maxsize=maxsize, by=by)
+
 Base.show(io::IO, lru::LRU{K, V}) where {K, V} =
     print(io, "LRU{$K, $V}(; maxsize = $(lru.maxsize))")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,25 +5,25 @@ using Base.Threads
 
 # Test insertion and reinsertion ordering
 @testset "Single-threaded insertion and reinsertion" begin
-    cache = LRU{Int, Int}(; maxsize = 100)
+    for cache in [LRU(; maxsize = 100), LRU{Int, Int}(; maxsize = 100)]
+        r = 1:100
+        for i in reverse(r)
+            cache[i] = i
+        end
+        @test collect(cache) == collect(i=>i for i in r)
 
-    r = 1:100
-    for i in reverse(r)
-        cache[i] = i
-    end
-    @test collect(cache) == collect(i=>i for i in r)
+        @threads for i = 1:10:100
+            @test haskey(cache, i)
+            @test !haskey(cache, 100+i)
+        end
 
-    @threads for i = 1:10:100
-        @test haskey(cache, i)
-        @test !haskey(cache, 100+i)
+        # reinsert in random order
+        p = randperm(100)
+        for i in reverse(p)
+            cache[i] = i
+        end
+        @test collect(cache) == collect(i=>i for i in p)
     end
-
-    # reinsert in random order
-    p = randperm(100)
-    for i in reverse(p)
-        cache[i] = i
-    end
-    @test collect(cache) == collect(i=>i for i in p)
 end
 
 @testset "Multi-threaded insertion and reinsertion" begin


### PR DESCRIPTION
* The `maxsize` keyword is still required, but the type parameters
  default to `Any`

Rationale:
* Most `AbstractDict` types offer a default (non-optimized) constructor.
* This would make it easier to use LRU in conjunction with Memoize.jl (with https://github.com/JuliaCollections/Memoize.jl/pull/51)

