### PR TITLE
Do not retain lock during `default()` call in `get(!)`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.4
+  - julia_version: 1
   - julia_version: nightly
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.4
+  - 1
   - nightly
 env:
   - JULIA_NUM_THREADS=1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LRUCache"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
-version = "1.1.0"
+version = "1.2.0"
 
 [compat]
 julia = "1"

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -67,10 +67,9 @@ function Base.get(default::Callable, lru::LRU, key)
         if _unsafe_haskey(lru, key)
             v = _unsafe_getindex(lru, key)
             return v
-        else
-            return default()
         end
     end
+    return default()
 end
 function Base.get!(lru::LRU, key, default)
     lock(lru.lock) do
@@ -90,7 +89,9 @@ function Base.get!(default::Callable, lru::LRU, key)
             v = _unsafe_getindex(lru, key)
             return v
         end
-        v = default()
+    end
+    v = default()
+    lock(lru.lock) do
         _unsafe_addindex!(lru, v, key)
         _unsafe_resize!(lru)
         return v

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -96,8 +96,13 @@ function Base.get!(default::Callable, lru::LRU, key)
     end
     v = default()
     lock(lru.lock)
-    _unsafe_addindex!(lru, v, key)
-    _unsafe_resize!(lru)
+    if _unsafe_haskey(lru, key)
+        # should we test that this yields the same result as default()
+        v = _unsafe_getindex(lru, key)
+    else
+        _unsafe_addindex!(lru, v, key)
+        _unsafe_resize!(lru)
+    end
     unlock(lru.lock)
     return v
 end


### PR DESCRIPTION
The point of this PR is to release the lock while calling `default()` in `get` or `get!`. In particular, this allows for the `default()` function to itself depend on the lru cache. Previously, this would have resulted in a deadlock.