### PR TITLE
Implement eviction callback.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,8 +6,8 @@ version = "1.2.0"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Random"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ operations are shown below:
 **Creation**
 
 ```julia
-lru = LRU{K, V}(, maxsize = size [, by = ...])
+lru = LRU{K, V}(, maxsize = size [, by = ...] [,eviction_callback = ...])
 ```
 
 Create an LRU Cache with a maximum size (number of items) specified by the *required*
@@ -39,6 +39,10 @@ function (which should return a single value of type `Int`) specified with the k
 argument `by`. Sensible choices would for example be `by = sizeof` for e.g. values which
 are `Array`s of bitstypes, or `by = Base.summarysize` for values of some arbitrary user
 type.
+
+If `eviction_callback` is set, it is called for each entry that leaves the cache,
+with `key` and `value` as arguments. This is useful if the cached values contain some
+resource that you want to recover.
 
 **Add an item to the cache**
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,38 +154,42 @@ end
 end
 
 @testset "Eviction callback" begin
-    resources = Channel{Matrix{Float64}}(11)
-    for _ = 1:11
-        put!(resources, zeros(5, 5))
-    end
-    callback = (key, value) -> put!(resources, value)
-    cache = LRU{Int,Matrix{Float64}}(; maxsize = 10,
-                                     eviction_callback = callback)
+    # Julia 1.0 and 1.1 crash with multiple threads on this
+    # combination of @threads and Channel.
+    if VERSION >= v"1.2" || Threads.nthreads() == 1
+        resources = Channel{Matrix{Float64}}(11)
+        for _ = 1:11
+            put!(resources, zeros(5, 5))
+        end
+        callback = (key, value) -> put!(resources, value)
+        cache = LRU{Int,Matrix{Float64}}(; maxsize = 10,
+                                         eviction_callback = callback)
 
-    @threads for i = 1:100
-        cache[i ÷ gcd(i, 60)] = take!(resources)
+        @threads for i = 1:100
+            cache[i ÷ gcd(i, 60)] = take!(resources)
+        end
+        # Note: It's not ideal to rely on the Channel internals but there
+        # doesn't seem to be a public way to check how much is occupied.
+        @test length(resources.data) == 1
+        cache[101] = take!(resources)
+        @test length(resources.data) == 1
+        pop!(cache, 101)
+        @test length(resources.data) == 2
+        cache[101] = take!(resources)
+        @test length(resources.data) == 1
+        delete!(cache, 101)
+        @test length(resources.data) == 2
+        get!(cache, 101, take!(resources))
+        @test length(resources.data) == 1
+        get!(() -> take!(resources), cache, 102)
+        @test length(resources.data) == 1
+        get!(() -> take!(resources), cache, 102)
+        @test length(resources.data) == 1
+        resize!(cache, maxsize = 5)
+        @test length(resources.data) == 6
+        empty!(cache)
+        @test length(resources.data) == 11
     end
-    # Note: It's not ideal to rely on the Channel internals but there
-    # doesn't seem to be a public way to check how much is occupied.
-    @test length(resources.data) == 1
-    cache[101] = take!(resources)
-    @test length(resources.data) == 1
-    pop!(cache, 101)
-    @test length(resources.data) == 2
-    cache[101] = take!(resources)
-    @test length(resources.data) == 1
-    delete!(cache, 101)
-    @test length(resources.data) == 2
-    get!(cache, 101, take!(resources))
-    @test length(resources.data) == 1
-    get!(() -> take!(resources), cache, 102)
-    @test length(resources.data) == 1
-    get!(() -> take!(resources), cache, 102)
-    @test length(resources.data) == 1
-    resize!(cache, maxsize = 5)
-    @test length(resources.data) == 6
-    empty!(cache)
-    @test length(resources.data) == 11
 end
 
 include("originaltests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,4 +153,39 @@ end
     end
 end
 
+@testset "Eviction callback" begin
+    resources = Channel{Matrix{Float64}}(11)
+    for _ = 1:11
+        put!(resources, zeros(5, 5))
+    end
+    callback = (key, value) -> put!(resources, value)
+    cache = LRU{Int,Matrix{Float64}}(; maxsize = 10,
+                                     eviction_callback = callback)
+
+    @threads for i = 1:100
+        cache[i ÷ gcd(i, 60)] = take!(resources)
+    end
+    # Note: It's not ideal to rely on the Channel internals but there
+    # doesn't seem to be a public way to check how much is occupied.
+    @test length(resources.data) == 1
+    cache[101] = take!(resources)
+    @test length(resources.data) == 1
+    pop!(cache, 101)
+    @test length(resources.data) == 2
+    cache[101] = take!(resources)
+    @test length(resources.data) == 1
+    delete!(cache, 101)
+    @test length(resources.data) == 2
+    get!(cache, 101, take!(resources))
+    @test length(resources.data) == 1
+    get!(() -> take!(resources), cache, 102)
+    @test length(resources.data) == 1
+    get!(() -> take!(resources), cache, 102)
+    @test length(resources.data) == 1
+    resize!(cache, maxsize = 5)
+    @test length(resources.data) == 6
+    empty!(cache)
+    @test length(resources.data) == 11
+end
+
 include("originaltests.jl")


### PR DESCRIPTION
This PR adds an eviction callback, which if set is called for each element that leaves the cache. This is useful if your cached values contain some resource that you want to recover. PR #1 had the same idea but is very much out of date with respect to the code.

Unfortunately this functionality doesn't come entirely for free, even if no callback is set. In terms of `test/benchmark.jl` the timing differences seem to be within the measurement noise but what is definitely noticeable is that all functions that may cause eviction (`setindex!`, `get!`, `pop!`, `delete!`, `resize!`, `empty!`) get one extra allocation of 80 bytes to hold the empty list of pending evictions.

To avoid this allocation will either require:
1. Notify the callback while the lock is held. This seems inadvisable.
2. Increase the implementation complexity in some way to avoid the allocation, possibly with function barriers to induce code specialization via some type trick or constant propagation.
3. Some brilliant insight that avoids the allocation in a simple way. Haven't been that lucky so far.
