### PR TITLE
added Iterators.reverse methods to support lazy reverse traversal

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,0 @@
-# This file is machine-generated - editing it directly is not advised
-
-julia_version = "1.7.1"
-manifest_format = "2.0"
-
-[deps]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,6 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.1"
+manifest_format = "2.0"
+
+[deps]

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -236,9 +236,9 @@ end
 # Reverse iterator for LRUCache.LRU
 Base.eltype(::Type{Iterators.Reverse{LRUCache.LRU{T}}}) where {T} = eltype(T)
 Base.IteratorSize(::Type{Iterators.Reverse{LRUCache.LRU{T}}}) where {T} = Base.IteratorSize(LRUCache.CyclicOrderedSet)
-Base.IteratorEltype(::Type{Iterators.Reverse{LRUCache.LRU{T}}}) where {T} = Base.IteratorSize(LRUCache.LRU)
-Base.length(lru::Iterators.Reverse{LRUCache.LRU{T}}) where {T} = length(lru.keyset)
-Base.isempty(lru::Iterators.Reverse{LRUCache.LRU{T}}) where {T} = isempty(lru.keyset)
+Base.IteratorEltype(::Type{Iterators.Reverse{LRUCache.LRU{T}}}) where {T} = Base.IteratorEltype(LRUCache.LRU)
+Base.length(lru::Iterators.Reverse{LRUCache.LRU{T}}) where {T} = length(lru.itr.keyset)
+Base.isempty(lru::Iterators.Reverse{LRUCache.LRU{T}}) where {T} = isempty(lru.itr.keyset)
 
 function Base.iterate(lru::Iterators.Reverse{LRU{T,B}}, state...) where {T,B}
     next = iterate(Iterators.Reverse(lru.itr.keyset), state...)
@@ -250,6 +250,5 @@ function Base.iterate(lru::Iterators.Reverse{LRU{T,B}}, state...) where {T,B}
         return k=>v, state
     end
 end
-
 
 end # module

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -3,6 +3,7 @@ module LRUCache
 include("cyclicorderedset.jl")
 export LRU
 
+using Base.Iterators
 using Base.Threads
 using Base: Callable
 
@@ -231,5 +232,24 @@ function _finalize_evictions!(finalizer, evictions)
     end
     return
 end
+
+# Reverse iterator for LRUCache.LRU
+Base.eltype(::Type{Iterators.Reverse{LRUCache.LRU{T}}}) where {T} = eltype(T)
+Base.IteratorSize(::Type{Iterators.Reverse{LRUCache.LRU{T}}}) where {T} = Base.IteratorSize(LRUCache.CyclicOrderedSet)
+Base.IteratorEltype(::Type{Iterators.Reverse{LRUCache.LRU{T}}}) where {T} = Base.IteratorSize(LRUCache.LRU)
+Base.length(lru::Iterators.Reverse{LRUCache.LRU{T}}) where {T} = length(lru.keyset)
+Base.isempty(lru::Iterators.Reverse{LRUCache.LRU{T}}) where {T} = isempty(lru.keyset)
+
+function Base.iterate(lru::Iterators.Reverse{LRU{T,B}}, state...) where {T,B}
+    next = iterate(Iterators.Reverse(lru.itr.keyset), state...)
+    if next === nothing
+        return nothing
+    else
+        k, state = next
+        v, = lru.itr.dict[k]
+        return k=>v, state
+    end
+end
+
 
 end # module

--- a/src/cyclicorderedset.jl
+++ b/src/cyclicorderedset.jl
@@ -168,7 +168,7 @@ end
 # Reverse iterator for LRUCache.CyclicOrderedSet
 Base.eltype(::Type{Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}}) where {T} = eltype(T)
 Base.IteratorSize(::Type{Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}}) where {T} = Base.IteratorSize(LRUCache.CyclicOrderedSet)
-Base.IteratorEltype(::Type{Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}}) where {T} = Base.IteratorSize(LRUCache.CyclicOrderedSet)
+Base.IteratorEltype(::Type{Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}}) where {T} = Base.IteratorEltype(LRUCache.CyclicOrderedSet)
 Base.last(r::Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}) where {T} = first(r.itr)
 Base.first(r::Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}) where {T} = r.itr.first.prev.val
 

--- a/src/cyclicorderedset.jl
+++ b/src/cyclicorderedset.jl
@@ -164,3 +164,21 @@ function _move_to_front!(s::CyclicOrderedSet{T}, n::LinkedNode{T}) where {T}
     end
     return s
 end
+
+# Reverse iterator for LRUCache.CyclicOrderedSet
+Base.eltype(::Type{Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}}) where {T} = eltype(T)
+Base.IteratorSize(::Type{Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}}) where {T} = Base.IteratorSize(LRUCache.CyclicOrderedSet)
+Base.IteratorEltype(::Type{Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}}) where {T} = Base.IteratorSize(LRUCache.CyclicOrderedSet)
+Base.last(r::Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}) where {T} = first(r.itr)
+Base.first(r::Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}) where {T} = r.itr.first.prev.val
+
+function Base.iterate(
+    s::Iterators.Reverse{LRUCache.CyclicOrderedSet{T}}, 
+    state = (s.itr.first isa Nothing) ? nothing : s.itr.first.prev
+) where {T}
+    if state === nothing
+        return nothing
+    else
+        return state.val, state.prev.val == first(s) ? nothing : state.prev
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,7 +191,7 @@ end
     end
 end
 
-@testset "reverse iterator" begin
+@testset "Reverse iterator" begin
     lru = LRU(;maxsize = 4)
     # Instantiate lazy reverse iterator
     rlru = Iterators.reverse(lru)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,4 +191,31 @@ end
     end
 end
 
+@testset "reverse iterator" begin
+    lru = LRU(;maxsize = 4)
+    # Instantiate lazy reverse iterator
+    rlru = Iterators.reverse(lru)
+    # Did we handle the empty cache?
+    @test [k => v for (k,v) in lru] == []       
+    @test [k => v for (k,v) in rlru] == []
+    # Fill in some data
+    lru["first"] = 1
+    # Does a single element cache work
+    @test [k => v for (k,v) in lru] == ["first" => 1]        
+    @test [k => v for (k,v) in rlru] == ["first" => 1]
+    lru["second"] = 2
+    # Does a partially filled cache work
+    @test [k => v for (k,v) in lru] == ["second" => 2, "first" => 1]        
+    @test [k => v for (k,v) in rlru] == ["first" => 1, "second" => 2]
+    lru["third"] = 3
+    lru["fourth"] = 4
+    # Does forward iteration give us the expected result?
+    @test [k => v for (k,v) in lru] == ["fourth" => 4, "third" => 3, "second" => 2, "first" => 1]
+    @test [k => v for (k,v) in rlru] == ["first" => 1, "second" => 2, "third" => 3, "fourth" => 4]
+    # Evict first by inserting fifth
+    lru["fifth"] = 5
+    @test [k => v for (k,v) in lru] == ["fifth" => 5, "fourth" => 4, "third" => 3, "second" => 2]
+    @test [k => v for (k,v) in rlru] == ["second" => 2, "third" => 3, "fourth" => 4, "fifth" => 5]
+end
+
 include("originaltests.jl")


### PR DESCRIPTION
Found this useful in a project (currently stubbing in the function calls now)... Sometimes the things at the bottom of the LRUCache are "interesting" and iterating in the typical sense is costly. Meanwhile reverse iteration is very much possible with the machinery in place. 

Let me know what you all think.