### PR TITLE
Max size is a required argument making a read me example wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ As this function requires more than one parameter, we need a cache from
 `(Float64, Float64)` to `Float64`. A cached version is then:
 
 ```julia
-const lru = LRU{Tuple{Float64, Float64}, Float64}()
+const lru = LRU{Tuple{Float64, Float64}, Float64}(maxsize=10)
 
 function cached_foo(a::Float64, b::Float64)
     get!(lru, (a, b)) do


### PR DESCRIPTION
This is a trivial change but should make it slightly easier for new users. `max_size` is a required argument so its absence makes the bottom example fail. In the [creation section](https://github.com/JuliaCollections/LRUCache.jl/blob/master/README.md#interface) it is suggested that `max_size` has a default value but for me this doesn't seem to be the case, perhaps this needs updating/rectifying too. 