### PR TITLE
fix lock usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.jl.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LRUCache"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
-version = "1.4.0"
+version = "1.4.1"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
closes https://github.com/JuliaCollections/LRUCache.jl/issues/31

There are already tests which should cover this, but they don't seem to be causing issues on main. I did check that the original example from #31,
```julia

import Memoize: @memoize
import LRUCache: LRU

@memoize LRU{Int,Int}(maxsize=1000) foo(i::Int) = i

foo(5)
```
does now work (it throws an error no matter how many times I call it), whereas for me on main it throws an error, but then a second invocation of `foo` hangs.

~~Here I use `Base.@lock`, which is document+exported on Julia 1.9+, so should be fine to use here (non-internal).~~
Nevermind, `@lock` isn't defined on 1.0, so I'll just use manual `finally` calls.