### PR TITLE
Update TagBot.yml

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,22 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
@@ -12,4 +28,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Based on https://github.com/JuliaRegistries/TagBot#setup

We don't have Documenter docs here so we don't need the ssh key line (and if we don't have an ssh key configured for the repo, I wonder if that could cause the permissions error? Or if TagBot would just skip it?)

Once this is merged, you can try it out by going to https://github.com/JuliaCollections/LRUCache.jl/actions/workflows/TagBot.yml and clicking a "run workflow" button to manually trigger TagBot. It should by default look for releases to tag from within the last 3 days, but that number is configurable w/ this PR