### PR TITLE
add `cache_info`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LRUCache"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
-version = "1.5.0"
+version = "1.6.0"
 
 [compat]
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ storing this value in `lru`. Also comes in the following form:
 
 #### get(default::Callable, lru::LRU, key)
 
+#### cache_info(lru::LRU)
+
+Returns a struct holding a snapshot of information about hits, misses, current size, and total size in is properties.
+
+The caching functions `get` and `get!` each contribute a cache hit or miss on every function call (depending on whether or not the key was found). `empty!` resets the counts of hits and misses to 0.
+
+The other functions, e.g. `getindex` `iterate`, `haskey`, `setindex!`, `delete!`, and `pop!` do not contribute cache hits or misses, regardless of whether or not a key is retrieved. This is because it is not possible to use these functions for caching.
+
 ## Example
 
 Commonly, you may have some long running function that sometimes gets called with the same
@@ -130,3 +138,5 @@ function cached_foo(a::Float64, b::Float64)
     end
 end
 ```
+
+If we want to see how our cache is performing, we can call `cache_info` to see the number of cache hits and misses.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ storing this value in `lru`. Also comes in the following form:
 
 #### cache_info(lru::LRU)
 
-Returns a struct holding a snapshot of information about hits, misses, current size, and total size in is properties.
+Returns an object holding a snapshot of information about hits, misses, current size, and total size in its properties.
 
 The caching functions `get` and `get!` each contribute a cache hit or miss on every function call (depending on whether or not the key was found). `empty!` resets the counts of hits and misses to 0.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using LRUCache
+using LRUCache: CacheInfo
 using Test
 using Random
 using Base.Threads
@@ -250,6 +251,49 @@ end
     lru[2] = 1:11
     @test !haskey(lru, 2) # don't keep the old entry!
     @test lru[1] == 1:9
+end
+
+@testset "cache_info" begin
+    lru = LRU{Int, Float64}(; maxsize=10)
+
+    get!(lru, 1, 1.0) # miss
+    @test cache_info(lru) == CacheInfo(; hits=0, misses=1, currentsize=1, maxsize=10)
+
+    get!(lru, 1, 1.0) # hit
+    @test cache_info(lru) == CacheInfo(; hits=1, misses=1, currentsize=1, maxsize=10)
+
+    get(lru, 1, 1.0) # hit
+    @test cache_info(lru) == CacheInfo(; hits=2, misses=1, currentsize=1, maxsize=10)
+
+    get(lru, 2, 1.0) # miss
+    info = CacheInfo(; hits=2, misses=2, currentsize=1, maxsize=10)
+    @test cache_info(lru) == info
+    @test sprint(show, info) == "CacheInfo(; hits=2, misses=2, currentsize=1, maxsize=10)"
+
+
+    # These don't change the hits and misses
+    @test haskey(lru, 1)
+    @test cache_info(lru) == info
+    @test lru[1] == 1.0
+    @test cache_info(lru) == info
+    @test !haskey(lru, 2)
+    @test cache_info(lru) == info
+
+    # This affects `currentsize` but not hits or misses
+    delete!(lru, 1)
+    @test cache_info(lru) == CacheInfo(; hits=2, misses=2, currentsize=0, maxsize=10)
+
+    # Likewise setindex! does not affect hits or misses, just `currentsize`
+    lru[1] = 1.0
+    @test cache_info(lru) == info
+
+    # Only affects size
+    pop!(lru, 1)
+    @test cache_info(lru) == CacheInfo(; hits=2, misses=2, currentsize=0, maxsize=10)
+
+    # Resets counts
+    empty!(lru)
+    @test cache_info(lru) == CacheInfo(; hits=0, misses=0, currentsize=0, maxsize=10)
 end
 
 include("originaltests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -270,7 +270,6 @@ end
     @test cache_info(lru) == info
     @test sprint(show, info) == "CacheInfo(; hits=2, misses=2, currentsize=1, maxsize=10)"
 
-
     # These don't change the hits and misses
     @test haskey(lru, 1)
     @test cache_info(lru) == info


### PR DESCRIPTION
closes https://github.com/JuliaCollections/LRUCache.jl/issues/28

I think this should have minimal performance impact, since we simply increment an integer on hits/misses. We are already in the lock in each case, so we don't need to take it.

Some choices:
* I reset the stats on `empty!`, like how functools clears both entries and stats on `empty_cache()`.
* I only count hits/misses on `get` and `get!` since those are on the only viable methods to use for caching. e.g. `setindex!` doesn't care about the existing value so it doesn't make sense to count it as a hit/miss. And `getindex` errors if the value is not present, so it doesn't really seem like that should count as a cache miss (rather, it is exceptional behavior). This aligns with the README documentation that only describes `get` and `get!` as fulfilling a caching interface.
* I use a similar `show` method to functools, since it clearly communicates how to access the entries. I switched the order slightly compared to functools (`currentsize` before `maxsize` because it makes more sense to me).
* `cache_info` provides an immutable snapshot rather than a reference to the cache. This way there isn't a need for locking on access to to the cache info fields.
* I use "properties" rather than "fields" in the docstring/documentation so if needed we can change the fields while exposing `getproperty` overloads for api compatibility. I don't forsee that we would need this though.

To check it is correct according to this api, check that every branch of `get` and `get!` either increments a hit or a miss, and does so within the lock. (I believe I've done so).