### PR TITLE
Add support for serialization of large caches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,19 +2,22 @@ name = "LRUCache"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 version = "1.6.1"
 
-[compat]
-julia = "≥ 1.9"
-
-[extras]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+[deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[targets]
-test = ["Test", "Random", "Serialization"]
 
 [weakdeps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [extensions]
 SerializationExt = ["Serialization"]
+
+[compat]
+julia = "1"
+
+[extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Random", "Serialization"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,9 @@
 name = "LRUCache"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
-version = "1.6.0"
+version = "1.6.1"
 
 [compat]
-julia = "1"
+julia = "≥ 1.9"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,13 @@ julia = "1"
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "Serialization"]
+
+[weakdeps]
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[extensions]
+SerializationExt = ["Serialization"]

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -7,6 +7,7 @@ using Serialization
 function Serialization.serialize(s::AbstractSerializer, lru::LRU{K, V}) where {K, V}
     # Create a mapping from memory address to id
     node_map = IdDict{LRUCache.LinkedNode{K}, Int}()
+    sizehint!(node_map, length(lru))
     # Create mapping for first node
     id = 1
     first_node = node = lru.keyset.first

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -59,8 +59,8 @@ function Serialization.deserialize(s::AbstractSerializer, ::Type{LRU{K, V}}) whe
     end
     # Link the nodes
     for (idx, node) in enumerate(nodes)
-        node.next = nodes[idx % n_nodes + 1]
-        node.prev = nodes[idx == 1 ? n_nodes : idx - 1]
+        node.next = nodes[mod1(idx+1, n_nodes)]
+        node.prev = nodes[mod1(idx-1, n_nodes)]
     end
     # Create keyset with first node and n_nodes
     keyset = LRUCache.CyclicOrderedSet{K}()

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -51,7 +51,7 @@ function Serialization.deserialize(s::AbstractSerializer, ::Type{LRU{K, V}}) whe
         end
     end
     # close the chain if any node exists
-    if !isnothing(node)
+    if node !== nothing
         node.next = first
         first.prev = node
     end

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -16,6 +16,8 @@ function Serialization.serialize(s::AbstractSerializer, lru::LRU{K, V}) where {K
     for (k, val) in lru
         serialize(s, k)
         serialize(s, val)
+        sz = lru.dict[k][3]
+        serialize(s, sz)
     end
 end
 
@@ -38,7 +40,7 @@ function Serialization.deserialize(s::AbstractSerializer, ::Type{LRU{K, V}}) whe
         k = deserialize(s)
         node = LRUCache.LinkedNode{K}(k)
         val = deserialize(s)
-        sz = by(val)::Int
+        sz = deserialize(s)
         dict[k] = (val, node, sz)
         if i == 1 
             first = node

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -1,0 +1,83 @@
+module SerializationExt
+export serialize, deserialize
+using LRUCache
+using Serialization
+
+# Serialization of large LRUs causes a stack overflow error, so we 
+# create a custom serializer that represents LinkedNodes as Ints
+function Serialization.serialize(s::AbstractSerializer, lru::LRU{K, V}) where {K, V}
+    # Create a mapping from memory address to id
+    node_map = Dict{Ptr, Int}()
+    # Create mapping for first node
+    id = 1
+    first_node = node = lru.keyset.first
+    node_map[pointer_from_objref(node)] = id
+    # Go through the rest of the nodes in the cycle and create a mapping
+    node = node.next
+    while node != first_node
+        id += 1
+        node_map[pointer_from_objref(node)] = id
+        node = node.next
+    end
+    @assert id == length(lru) == lru.keyset.length == length(lru.dict)
+    # By this point, the first node has id 1 and the last node has id length(lru)
+    # so when deserializing, we can infer the order by the id
+    # Create the dict with ids instead of nodes
+    dict = Dict{K, Tuple{V, Int, Int}}()
+    for (key, (value, node, s)) in lru.dict
+        id = node_map[pointer_from_objref(node)]
+        dict[key] = (value, id, s)
+    end
+    Serialization.writetag(s.io, Serialization.OBJECT_TAG)
+    Serialization.serialize(s, typeof(lru))
+    Serialization.serialize(s, dict)
+    Serialization.serialize(s, lru.currentsize)
+    Serialization.serialize(s, lru.maxsize)
+    Serialization.serialize(s, lru.hits)
+    Serialization.serialize(s, lru.misses)
+    Serialization.serialize(s, lru.lock)
+    Serialization.serialize(s, lru.by)
+    Serialization.serialize(s, lru.finalizer)
+end
+
+function Serialization.deserialize(s::AbstractSerializer, ::Type{LRU{K, V}}) where {K, V}
+    dict_with_ids = Serialization.deserialize(s)
+    currentsize = Serialization.deserialize(s)
+    maxsize = Serialization.deserialize(s)
+    hits = Serialization.deserialize(s)
+    misses = Serialization.deserialize(s)
+    lock = Serialization.deserialize(s)
+    by = Serialization.deserialize(s)
+    finalizer = Serialization.deserialize(s)
+    # Create a new keyset and mapping from id to node
+    n_nodes = length(dict_with_ids)
+    nodes = Vector{LRUCache.LinkedNode{K}}(undef, n_nodes)
+    dict = Dict{K, Tuple{V, LRUCache.LinkedNode{K}, Int}}()
+    # Create the nodes, but don't link them yet
+    for (key, (value, id, s)) in dict_with_ids
+        nodes[id] = LRUCache.LinkedNode{K}(key)
+        dict[key] = (value, nodes[id], s)
+    end
+    # Link the nodes
+    for (idx, node) in enumerate(nodes)
+        node.next = nodes[idx % n_nodes + 1]
+        node.prev = nodes[idx == 1 ? n_nodes : idx - 1]
+    end
+    # Create keyset with first node and n_nodes
+    keyset = LRUCache.CyclicOrderedSet{K}()
+    keyset.first = nodes[1]
+    keyset.length = n_nodes
+    # Create LRU
+    lru = LRU{K,V}(maxsize=maxsize)
+    lru.dict = dict
+    lru.keyset = keyset
+    lru.currentsize = currentsize
+    lru.hits = hits
+    lru.misses = misses
+    lru.lock = lock
+    lru.by = by
+    lru.finalizer = finalizer
+    lru
+end
+
+end

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -1,5 +1,4 @@
 module SerializationExt
-export serialize, deserialize
 using LRUCache
 using Serialization
 

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -23,9 +23,9 @@ function Serialization.serialize(s::AbstractSerializer, lru::LRU{K, V}) where {K
     # so when deserializing, we can infer the order by the id
     # Create the dict with ids instead of nodes
     dict = Dict{K, Tuple{V, Int, Int}}()
-    for (key, (value, node, s)) in lru.dict
+    for (key, (value, node, sz)) in lru.dict
         id = node_map[node]
-        dict[key] = (value, id, s)
+        dict[key] = (value, id, sz)
     end
     Serialization.writetag(s.io, Serialization.OBJECT_TAG)
     Serialization.serialize(s, typeof(lru))

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -317,3 +317,7 @@ function _finalize_evictions!(finalizer, evictions)
 end
 
 end # module
+
+if !isdefined(Base, :get_extension)
+  include("../ext/SerializationExt.jl")
+end

--- a/src/LRUCache.jl
+++ b/src/LRUCache.jl
@@ -316,8 +316,8 @@ function _finalize_evictions!(finalizer, evictions)
     return
 end
 
-end # module
-
 if !isdefined(Base, :get_extension)
-  include("../ext/SerializationExt.jl")
+    include("../ext/SerializationExt.jl")
 end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,3 +297,4 @@ end
 end
 
 include("originaltests.jl")
+include("serializationtests.jl")

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -1,0 +1,39 @@
+using Serialization
+@testset "Serialize and Deserialize" begin
+
+    cache = LRU{Int, Int}(maxsize=100_000)
+
+    # Populate the cache with dummy data
+    for i in 1:1_000_000
+        cache[i] = i+1
+    end
+    serialize("cache.jls", cache)
+    deserialized_cache = deserialize("cache.jls")
+    rm("cache.jls")
+
+    # Check that the cache is the same
+    @test cache.maxsize == deserialized_cache.maxsize
+    @test cache.currentsize == deserialized_cache.currentsize
+    @test cache.hits == deserialized_cache.hits
+    @test cache.misses == deserialized_cache.misses
+    @test cache.by == deserialized_cache.by
+    @test cache.finalizer == deserialized_cache.finalizer
+    @test cache.keyset.length == deserialized_cache.keyset.length
+    @test length(cache.dict) == length(deserialized_cache.dict)
+    # Check that the cache has the same keyset
+    c_node = cache.keyset.first
+    d_node = deserialized_cache.keyset.first
+    for i in 1:cache.keyset.length
+        c_node.val == d_node.val || @test false
+        c_node = c_node.next
+        d_node = d_node.next
+    end
+    # Check that the cache keys, values, and sizes are the same
+    for (key, (c_value, c_node, c_s)) in cache.dict
+        d_value, d_node, d_s = deserialized_cache.dict[key]
+        c_value == d_value || @test false
+        c_node.val == d_node.val || @test false
+        c_s == d_s || @test false
+    end
+end
+

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -4,32 +4,33 @@ using Serialization
     cache = LRU{Int, Int}(maxsize=100_000)
 
     # Populate the cache with dummy data
-    for i in 1:1_000_000
+    num_entries_to_test = [0, 1, 2, 3, 4, 5, 100_000, 1_000_000]
+    for i in 0:maximum(num_entries_to_test)
+        i ∈ num_entries_to_test || continue
+        io = IOBuffer()
+        serialize(io, cache)
+        seekstart(io)
+        deserialized_cache = deserialize(io)
+
+        # Check that the cache is the same
+        @test cache.maxsize == deserialized_cache.maxsize
+        @test cache.currentsize == deserialized_cache.currentsize
+        @test cache.hits == deserialized_cache.hits
+        @test cache.misses == deserialized_cache.misses
+        @test cache.by == deserialized_cache.by
+        @test cache.finalizer == deserialized_cache.finalizer
+        @test cache.keyset.length == deserialized_cache.keyset.length
+        @test issetequal(collect(cache), collect(deserialized_cache))
+        # Check that the cache has the same keyset
+        @test length(cache.keyset) == length(deserialized_cache.keyset)
+        @test all(((c_val, d_val),) -> c_val == d_val, zip(cache.keyset, deserialized_cache.keyset))
+        # Check that the cache keys, values, and sizes are the same
+        for (key, (c_value, c_node, c_s)) in cache.dict
+            d_value, d_node, d_s = deserialized_cache.dict[key]
+            c_value == d_value || @test false
+            c_node.val == d_node.val || @test false
+            c_s == d_s || @test false
+        end
         cache[i] = i+1
     end
-    io = IOBuffer()
-    serialize(io, cache)
-    seekstart(io)
-    deserialized_cache = deserialize(io)
-
-    # Check that the cache is the same
-    @test cache.maxsize == deserialized_cache.maxsize
-    @test cache.currentsize == deserialized_cache.currentsize
-    @test cache.hits == deserialized_cache.hits
-    @test cache.misses == deserialized_cache.misses
-    @test cache.by == deserialized_cache.by
-    @test cache.finalizer == deserialized_cache.finalizer
-    @test cache.keyset.length == deserialized_cache.keyset.length
-    @test issetequal(collect(cache), collect(deserialized_cache))
-    # Check that the cache has the same keyset
-    @test length(cache.keyset) == length(deserialized_cache.keyset)
-    @test all(((c_val, d_val),) -> c_val == d_val, zip(cache.keyset, deserialized_cache.keyset))
-    # Check that the cache keys, values, and sizes are the same
-    for (key, (c_value, c_node, c_s)) in cache.dict
-        d_value, d_node, d_s = deserialized_cache.dict[key]
-        c_value == d_value || @test false
-        c_node.val == d_node.val || @test false
-        c_s == d_s || @test false
-    end
 end
-

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -6,6 +6,9 @@ using Serialization
     # Populate the cache with dummy data
     num_entries_to_test = [0, 1, 2, 3, 4, 5, 100_000, 1_000_000]
     for i in 0:maximum(num_entries_to_test)
+        # Add dummy data on all but the first iteration,
+        # to test an empty cache
+        i > 0 && (cache[i] = i+1)
         i ∈ num_entries_to_test || continue
         io = IOBuffer()
         serialize(io, cache)
@@ -31,7 +34,6 @@ using Serialization
             c_node.val == d_node.val || @test false
             c_s == d_s || @test false
         end
-        cache[i] = i+1
     end
 end
 

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -22,13 +22,8 @@ using Serialization
     @test cache.keyset.length == deserialized_cache.keyset.length
     @test issetequal(collect(cache), collect(deserialized_cache))
     # Check that the cache has the same keyset
-    c_node = cache.keyset.first
-    d_node = deserialized_cache.keyset.first
-    for i in 1:cache.keyset.length
-        c_node.val == d_node.val || @test false
-        c_node = c_node.next
-        d_node = d_node.next
-    end
+    @test length(cache.keyset) == length(deserialized_cache.keyset)
+    @test all(((c_val, d_val),) -> c_val == d_val, zip(cache.keyset, deserialized_cache.keyset))
     # Check that the cache keys, values, and sizes are the same
     for (key, (c_value, c_node, c_s)) in cache.dict
         d_value, d_node, d_s = deserialized_cache.dict[key]

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -19,7 +19,7 @@ using Serialization
     @test cache.by == deserialized_cache.by
     @test cache.finalizer == deserialized_cache.finalizer
     @test cache.keyset.length == deserialized_cache.keyset.length
-    @test length(cache.dict) == length(deserialized_cache.dict)
+    @test issetequal(collect(cache), collect(deserialized_cache))
     # Check that the cache has the same keyset
     c_node = cache.keyset.first
     d_node = deserialized_cache.keyset.first

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -7,9 +7,10 @@ using Serialization
     for i in 1:1_000_000
         cache[i] = i+1
     end
-    serialize("cache.jls", cache)
-    deserialized_cache = deserialize("cache.jls")
-    rm("cache.jls")
+    io = IOBuffer()
+    serialize(io, cache)
+    seekstart(io)
+    deserialized_cache = deserialize(io)
 
     # Check that the cache is the same
     @test cache.maxsize == deserialized_cache.maxsize

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -1,5 +1,5 @@
 using Serialization
-@testset "Serialize and Deserialize" begin
+@testset "Large Serialize and Deserialize" begin
 
     cache = LRU{Int, Int}(maxsize=100_000)
 
@@ -33,4 +33,17 @@ using Serialization
         end
         cache[i] = i+1
     end
+end
+
+@testset "Serialize mutable references" begin
+    lru = LRU(; maxsize=5)
+    a = b = [1]
+    lru[1] = a
+    lru[2] = b
+    @test lru[1] === lru[2]
+    io = IOBuffer()
+    serialize(io, lru)
+    seekstart(io)
+    lru2 = deserialize(io)
+    @test lru2[1] === lru2[2]
 end


### PR DESCRIPTION
Fixes #45, where serialization of large LRU might result in a stack overflow. Does not automatically load Serialization, but uses extensions to overwrite Serialization.{serialize,deserialize} if Serialization is loaded, available in julia 1.9+.