### PR TITLE
Update serialization extension to support custom cache-size metric

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LRUCache"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/ext/SerializationExt.jl
+++ b/ext/SerializationExt.jl
@@ -5,14 +5,13 @@ using Serialization
 function Serialization.serialize(s::AbstractSerializer, lru::LRU{K, V}) where {K, V}
     Serialization.writetag(s.io, Serialization.OBJECT_TAG)
     serialize(s, typeof(lru))
-    serialize(s, lru.currentsize)
+    serialize(s, length(lru))
     serialize(s, lru.maxsize)
     serialize(s, lru.hits)
     serialize(s, lru.misses)
     serialize(s, lru.lock)
     serialize(s, lru.by)
     serialize(s, lru.finalizer)
-    serialize(s, length(lru))
     for (k, val) in lru
         serialize(s, k)
         serialize(s, val)
@@ -22,17 +21,17 @@ function Serialization.serialize(s::AbstractSerializer, lru::LRU{K, V}) where {K
 end
 
 function Serialization.deserialize(s::AbstractSerializer, ::Type{LRU{K, V}}) where {K, V}
-    currentsize = Serialization.deserialize(s)
+    n_items = Serialization.deserialize(s)
     maxsize = Serialization.deserialize(s)
     hits = Serialization.deserialize(s)
     misses = Serialization.deserialize(s)
     lock = Serialization.deserialize(s)
     by = Serialization.deserialize(s)
     finalizer = Serialization.deserialize(s)
-    n_items = Serialization.deserialize(s)
 
     dict = Dict{K, Tuple{V, LRUCache.LinkedNode{K}, Int}}()
     sizehint!(dict, n_items)
+    currentsize = 0
     # Create node chain
     first = nothing
     node = nothing
@@ -43,6 +42,7 @@ function Serialization.deserialize(s::AbstractSerializer, ::Type{LRU{K, V}}) whe
         val = deserialize(s)
         sz = deserialize(s)
         dict[k] = (val, node, sz)
+        currentsize += sz
         if i == 1
             first = node
             continue

--- a/test/serializationtests.jl
+++ b/test/serializationtests.jl
@@ -1,6 +1,35 @@
 using Serialization
-@testset "Large Serialize and Deserialize" begin
 
+function test_is_equivalent(a::LRU, b::LRU)
+    # Check that the cache is the same
+    @test a.maxsize == b.maxsize
+    @test a.currentsize == b.currentsize
+    @test a.hits == b.hits
+    @test a.misses == b.misses
+    @test a.by == b.by
+    @test a.finalizer == b.finalizer
+    @test a.keyset.length == b.keyset.length
+    @test issetequal(collect(a), collect(b))
+    # Check that the cache has the same keyset
+    @test length(a.keyset) == length(b.keyset)
+    @test all(((c_val, d_val),) -> c_val == d_val, zip(a.keyset, b.keyset))
+    # Check that the cache keys, values, and sizes are the same
+    for (key, (c_value, c_node, c_s)) in a.dict
+        d_value, d_node, d_s = b.dict[key]
+        c_value == d_value || @test false
+        c_node.val == d_node.val || @test false
+        c_s == d_s || @test false
+    end
+end
+
+function roundtrip(lru::LRU)::LRU
+    io = IOBuffer()
+    serialize(io, lru)
+    seekstart(io)
+    deserialize(io)
+end
+
+@testset "Large Serialize and Deserialize" begin
     cache = LRU{Int, Int}(maxsize=100_000)
 
     # Populate the cache with dummy data
@@ -10,30 +39,8 @@ using Serialization
         # to test an empty cache
         i > 0 && (cache[i] = i+1)
         i ∈ num_entries_to_test || continue
-        io = IOBuffer()
-        serialize(io, cache)
-        seekstart(io)
-        deserialized_cache = deserialize(io)
 
-        # Check that the cache is the same
-        @test cache.maxsize == deserialized_cache.maxsize
-        @test cache.currentsize == deserialized_cache.currentsize
-        @test cache.hits == deserialized_cache.hits
-        @test cache.misses == deserialized_cache.misses
-        @test cache.by == deserialized_cache.by
-        @test cache.finalizer == deserialized_cache.finalizer
-        @test cache.keyset.length == deserialized_cache.keyset.length
-        @test issetequal(collect(cache), collect(deserialized_cache))
-        # Check that the cache has the same keyset
-        @test length(cache.keyset) == length(deserialized_cache.keyset)
-        @test all(((c_val, d_val),) -> c_val == d_val, zip(cache.keyset, deserialized_cache.keyset))
-        # Check that the cache keys, values, and sizes are the same
-        for (key, (c_value, c_node, c_s)) in cache.dict
-            d_value, d_node, d_s = deserialized_cache.dict[key]
-            c_value == d_value || @test false
-            c_node.val == d_node.val || @test false
-            c_s == d_s || @test false
-        end
+        test_is_equivalent(cache, roundtrip(cache))
     end
 end
 
@@ -43,9 +50,17 @@ end
     lru[1] = a
     lru[2] = b
     @test lru[1] === lru[2]
-    io = IOBuffer()
-    serialize(io, lru)
-    seekstart(io)
-    lru2 = deserialize(io)
+    lru2 = roundtrip(lru)
     @test lru2[1] === lru2[2]
+end
+
+@testset "Serialization with custom cache-size metric" begin
+    lru = LRU{String,Vector{UInt8}}(; maxsize = 1024, by = sizeof)
+    lru["a"] = rand(UInt8, 128)
+    lru["b"] = rand(UInt8, 256)
+    lru["c"] = rand(UInt8, 512)
+    @test lru.currentsize == 896
+    @test length(lru) == 3
+
+    test_is_equivalent(lru, roundtrip(lru))
 end


### PR DESCRIPTION
The current Serialization extension assumes the cache size is always the number of items in the cache. This PR allows serializing LRUs with custom `by` functions, where `lru.currentsize != length(lru)`.

- Fixes #51